### PR TITLE
Retain settings and game state when visiting settings mid-game.

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,12 +21,32 @@ export default function Home() {
   const [savedSettings, setSavedSettings] = useState<GameSettings | null>(null);
 
   const startGame = (config: GameSettings) => {
-    setGameState({
-      ...gameState,
-      dealingSpeed: config.dealingSpeed,
-      players: config.numPlayers,
-      playerName: config.playerName,
-    });
+    if (gameState.gameOver && config.numPlayers !== gameState.players) {
+      // When the player count changes on a completed game, useEffect([players])
+      // resets playerHands but leaves gameOver=true, freezing the game loop.
+      // Reset game-over state so the loop restarts with the new count.
+      setGameState({
+        ...gameState,
+        dealingSpeed: config.dealingSpeed,
+        players: config.numPlayers,
+        playerName: config.playerName,
+        cardsDealtOnTurn: 0,
+        commentary: [],
+        currentPlayerIdx: 0,
+        gameOver: false,
+        gameSummary: undefined,
+        highScore: 0,
+        pushMessage: undefined,
+        winner: undefined,
+      });
+    } else {
+      setGameState({
+        ...gameState,
+        dealingSpeed: config.dealingSpeed,
+        players: config.numPlayers,
+        playerName: config.playerName,
+      });
+    }
     setSavedSettings(config);
     setHasStarted(true);
     setIsViewingSettings(false);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,32 +7,49 @@ import { GameSetup } from "@/components/game-setup";
 import { GameControls } from "@/components/game-controls";
 import { EDealingSpeed } from "@/shared/types";
 
+interface GameSettings {
+  playerName: string;
+  numPlayers: number;
+  dealingSpeed: EDealingSpeed;
+}
+
 export default function Home() {
   const { gameState, newGame, setGameState, hitMe, stand } =
     useSimpleJackGame();
-  const [hasCompletedSetup, setHasCompletedSetup] = useState(false);
+  const [hasStarted, setHasStarted] = useState(false);
+  const [isViewingSettings, setIsViewingSettings] = useState(false);
+  const [savedSettings, setSavedSettings] = useState<GameSettings | null>(null);
 
-  const startGame = (config: {
-    playerName: string;
-    numPlayers: number;
-    dealingSpeed: EDealingSpeed;
-  }) => {
+  const startGame = (config: GameSettings) => {
     setGameState({
       ...gameState,
       dealingSpeed: config.dealingSpeed,
       players: config.numPlayers,
       playerName: config.playerName,
     });
-    setHasCompletedSetup(true);
+    setSavedSettings(config);
+    setHasStarted(true);
+    setIsViewingSettings(false);
   };
 
   const changeSettings = () => {
-    setHasCompletedSetup(false);
+    setIsViewingSettings(true);
   };
 
-  // Show setup screen only if user hasn't completed initial setup
-  if (!hasCompletedSetup || !gameState.players) {
-    return <GameSetup onStartGame={startGame} />;
+  const cancelSettings = () => {
+    setIsViewingSettings(false);
+  };
+
+  if (!hasStarted || isViewingSettings) {
+    return (
+      <GameSetup
+        onStartGame={startGame}
+        onCancel={hasStarted ? cancelSettings : undefined}
+        initialPlayerName={savedSettings?.playerName}
+        initialNumPlayers={savedSettings?.numPlayers}
+        initialDealingSpeed={savedSettings?.dealingSpeed}
+      />
+    );
   }
 
   const getPlayerDisplayName = (playerId: number) => {

--- a/src/components/game-setup.tsx
+++ b/src/components/game-setup.tsx
@@ -7,13 +7,23 @@ interface GameSetupProps {
     numPlayers: number;
     dealingSpeed: EDealingSpeed;
   }) => void;
+  onCancel?: () => void;
+  initialPlayerName?: string;
+  initialNumPlayers?: number;
+  initialDealingSpeed?: EDealingSpeed;
 }
 
-export function GameSetup({ onStartGame }: GameSetupProps) {
-  const [numPlayers, setNumPlayers] = useState<number | undefined>();
-  const [playerName, setPlayerName] = useState<string>("");
+export function GameSetup({
+  onStartGame,
+  onCancel,
+  initialPlayerName,
+  initialNumPlayers,
+  initialDealingSpeed,
+}: GameSetupProps) {
+  const [numPlayers, setNumPlayers] = useState<number | undefined>(initialNumPlayers);
+  const [playerName, setPlayerName] = useState<string>(initialPlayerName ?? "");
   const [dealingSpeed, setDealingSpeed] = useState<EDealingSpeed>(
-    EDealingSpeed.normal
+    initialDealingSpeed ?? EDealingSpeed.normal
   );
 
   const handleStartGame = () => {
@@ -134,6 +144,18 @@ export function GameSetup({ onStartGame }: GameSetupProps) {
               </span>
             )}
           </button>
+
+          {onCancel && (
+            <button
+              onClick={onCancel}
+              className="w-full py-4 px-6 rounded-xl font-bold text-lg transition-all duration-300 shadow-lg hover:shadow-xl transform bg-gradient-to-r from-gray-500 to-gray-600 hover:from-gray-600 hover:to-gray-700 text-white hover:scale-105 active:scale-95"
+            >
+              <span className="flex items-center justify-center space-x-2">
+                <span>✖️</span>
+                <span>Cancel</span>
+              </span>
+            </button>
+          )}
         </div>
 
         <div className="mt-8 text-center">


### PR DESCRIPTION
- page.tsx: track saved settings and an isViewingSettings flag so the game view is preserved when the user opens settings after a hand
- game-setup.tsx: accept initial values for name/players/speed so the form is pre-populated on re-entry; show a Cancel button when onCancel is provided (i.e. a game has already been played)