### PR TITLE
Add test scenarios for player count changes in settings

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1297,6 +1297,146 @@ describe("Simple Jack Game UI", () => {
       // Full state must be identical AFTER returning from settings
       assertState();
     });
+
+    // ─── scenario 9: decrease players 4→2, click Start Game ─────────────────
+    //
+    // When the player count changes, useEffect([players]) resets playerHands
+    // to empty but does NOT clear gameOver. The game loop then refuses to
+    // deal because it sees gameOver=true, leaving two blank panels on screen
+    // with "Play New Game" already visible. This test catches that regression.
+
+    test("decreasing number of players from 4 to 2 and clicking Start Game does not leave the game frozen on the old game-over state", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        // P4 (Dealer) hits blackjack in round 2 — no user decision needed.
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-King", "Hearts-9"],
+              "2": ["Clubs-8", "Diamonds-Jack"],
+              "3": ["Hearts-7", "Clubs-Queen"],
+              "4": ["Diamonds-Ace", "Spades-10"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("4");
+      await runTimers(15);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      // Open settings
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+      // Set name and new (lower) player count.
+      // fireEvent.change is used for the name so the test is robust whether
+      // the form is blank (current code) or pre-populated (after fix-settings).
+      await waitFor(() =>
+        fireEvent.change(screen.getByLabelText(/your name/i), {
+          target: { value: "TestUser" },
+        })
+      );
+      await waitFor(() =>
+        fireEvent.change(
+          screen.getByRole("combobox", { name: /number of players/i }),
+          { target: { value: "2" } }
+        )
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /start game/i }));
+
+      // If gameOver is not cleared, "Play New Game" appears immediately.
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      // After timers only 2 player panels should be present.
+      await runTimers(15);
+
+      await waitFor(() =>
+        expect(screen.getByTestId("player-1")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-2")).toBeInTheDocument()
+      );
+      expect(screen.queryByTestId("player-3")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("player-4")).not.toBeInTheDocument();
+    });
+
+    // ─── scenario 10: increase players 2→4, click Start Game ────────────────
+
+    test("increasing number of players from 2 to 4 and clicking Start Game does not leave the game frozen on the old game-over state", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        // P1 blackjacks; P2 receives one card before the game ends.
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-Ace", "Spades-King"],
+              "2": ["Clubs-10"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("2");
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      // Open settings
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+      await waitFor(() =>
+        fireEvent.change(screen.getByLabelText(/your name/i), {
+          target: { value: "TestUser" },
+        })
+      );
+      await waitFor(() =>
+        fireEvent.change(
+          screen.getByRole("combobox", { name: /number of players/i }),
+          { target: { value: "4" } }
+        )
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /start game/i }));
+
+      // If gameOver is not cleared, "Play New Game" appears immediately.
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      // After timers all 4 panels should be present.
+      await runTimers(15);
+
+      await waitFor(() =>
+        expect(screen.getByTestId("player-1")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-2")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-3")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-4")).toBeInTheDocument()
+      );
+    });
   });
 
   describe("Push scenarios", () => {

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1072,6 +1072,162 @@ describe("Simple Jack Game UI", () => {
       assertState();
     });
 
+    // ─── scenario 7: 4-player game, decrease to 2 in settings, cancel ───────
+    //
+    // P4 (Dealer) wins with Ace+10=21 in round 2 before the loop returns to
+    // P1 — no user decision is needed.
+    // P1=King+9=19, P2=8+Jack=18, P3=7+Queen=17, P4=Ace+10=21 (WIN)
+
+    test("4-player dealer-blackjack result is identical before and after settings where number of players was decreased to 2", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-King", "Hearts-9"],
+              "2": ["Clubs-8", "Diamonds-Jack"],
+              "3": ["Hearts-7", "Clubs-Queen"],
+              "4": ["Diamonds-Ace", "Spades-10"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("4");
+      await runTimers(15);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      const assertState = () => {
+        const p1 = screen.getByTestId("player-1");
+        const p2 = screen.getByTestId("player-2");
+        const p3 = screen.getByTestId("player-3");
+        const p4 = screen.getByTestId("player-4");
+
+        expect(within(p1).getByText("TestUser")).toBeInTheDocument();
+        expect(within(p1).getAllByText("King")).toHaveLength(2);
+        expect(within(p1).getAllByText("9")).toHaveLength(2);
+        expect(within(p1).getByText("19")).toBeInTheDocument();
+        expect(within(p1).queryByText("WIN!")).not.toBeInTheDocument();
+
+        expect(within(p2).getByText("Player 2")).toBeInTheDocument();
+        expect(within(p2).getAllByText("8")).toHaveLength(2);
+        expect(within(p2).getAllByText("Jack")).toHaveLength(2);
+        expect(within(p2).getByText("18")).toBeInTheDocument();
+
+        expect(within(p3).getByText("Player 3")).toBeInTheDocument();
+        expect(within(p3).getAllByText("7")).toHaveLength(2);
+        expect(within(p3).getAllByText("Queen")).toHaveLength(2);
+        expect(within(p3).getByText("17")).toBeInTheDocument();
+
+        expect(within(p4).getByText("Dealer")).toBeInTheDocument();
+        expect(within(p4).getAllByText("Ace")).toHaveLength(2);
+        // "10" appears twice as card corners; score is "21", not "10"
+        expect(within(p4).getAllByText("10")).toHaveLength(2);
+        expect(within(p4).getByText("21")).toBeInTheDocument();
+        expect(within(p4).getByText("WIN!")).toBeInTheDocument();
+
+        // Exactly 4 player panels — not 2
+        expect(screen.queryByTestId("player-5")).not.toBeInTheDocument();
+
+        expect(
+          screen.getByRole("button", { name: /play new game/i })
+        ).toBeInTheDocument();
+      };
+
+      // Verify full state BEFORE visiting settings
+      assertState();
+
+      // Visit settings, decrease to 2 players, then cancel
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+      await waitFor(() =>
+        fireEvent.change(
+          screen.getByRole("combobox", { name: /number of players/i }),
+          { target: { value: "2" } }
+        )
+      );
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+      // Full 4-player state must be identical AFTER cancelling
+      assertState();
+    });
+
+    // ─── scenario 8: 2-player game, increase to 4 in settings, cancel ───────
+
+    test("2-player blackjack win is identical before and after settings where number of players was increased to 4", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-Ace", "Spades-King"],
+              "2": ["Clubs-10", "Hearts-7"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("2");
+      await runTimers(6);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      const assertState = () => {
+        const p1 = screen.getByTestId("player-1");
+        const p2 = screen.getByTestId("player-2");
+
+        expect(within(p1).getByText("TestUser")).toBeInTheDocument();
+        expect(within(p1).getAllByText("Ace")).toHaveLength(2);
+        expect(within(p1).getAllByText("King")).toHaveLength(2);
+        expect(within(p1).getByText("21")).toBeInTheDocument();
+        expect(within(p1).getByText("WIN!")).toBeInTheDocument();
+
+        expect(within(p2).getByText("Dealer")).toBeInTheDocument();
+        // P2 received only Clubs-10; Hearts-7 was never dealt.
+        // "10" appears 3 times: score(10) + card corners(2).
+        expect(within(p2).getAllByText("10")).toHaveLength(3);
+        expect(within(p2).queryByText("7")).not.toBeInTheDocument();
+
+        // Exactly 2 player panels — not 4
+        expect(screen.queryByTestId("player-3")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("player-4")).not.toBeInTheDocument();
+
+        expect(
+          screen.getByRole("button", { name: /play new game/i })
+        ).toBeInTheDocument();
+      };
+
+      // Verify full state BEFORE visiting settings
+      assertState();
+
+      // Visit settings, increase to 4 players, then cancel
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+      await waitFor(() =>
+        fireEvent.change(
+          screen.getByRole("combobox", { name: /number of players/i }),
+          { target: { value: "4" } }
+        )
+      );
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+      // Full 2-player state must be identical AFTER cancelling
+      assertState();
+    });
+
     // ─── scenario 6: 2-player game, user busts, dealer wins ─────────────────
 
     test("2-player game where user busts and dealer wins is identical before and after visiting settings without making changes", async () => {


### PR DESCRIPTION
  - Scenario 7: 4-player → decrease to 2 → Cancel → full 4-player state retained (cards, scores, WIN!)
  - Scenario 8: 2-player → increase to 4 → Cancel → full 2-player state retained 
  - Scenario 9: 4-player → decrease to 2 → Start Game → game must not freeze on old game-over state
  - Scenario 10: 2-player → increase to 4 → Start Game → same check

  All 4 tests currently fail — they specify the source fixes that follow on a separate branch.