### PR TITLE
Fix shallow-copy mutation bug in dealCardToCurrentPlayer and stand

### DIFF
--- a/src/__tests__/use-simple-jack.test.tsx
+++ b/src/__tests__/use-simple-jack.test.tsx
@@ -414,13 +414,13 @@ describe("useSimpleJackGame Hook", () => {
         act(() => jest.runAllTimers());
       }
 
-      const { hitMe, stand } = result.current;
-
-      // User hits once to get 7, then stands
-      await waitFor(() => hitMe());
+      // User hits once to get 7, then stands.
+      // Use result.current.* to always get the latest closure — a captured
+      // reference would close over stale state before the hit updated the hand.
+      await waitFor(() => result.current.hitMe());
       act(() => jest.runAllTimers());
 
-      await waitFor(() => stand());
+      await waitFor(() => result.current.stand());
 
       // Let dealer play out and bust
       for (let i = 0; i < 10; i += 1) {
@@ -488,17 +488,13 @@ describe("useSimpleJackGame Hook", () => {
       expect(result.current.gameState.players).toBe(2);
       expect(result.current.gameState.playerName).toBe("TestUser");
 
-      // TODO: these assertions are skipped due to a shallow-copy mutation bug in
-      // dealCardToCurrentPlayer. The function does [...playerHands] which creates
-      // a new outer array but the hand OBJECTS inside are the same references.
-      // When it then does updatedPlayerHands[i].cards.push(card), it mutates the
-      // original hand object's cards array synchronously — before the setTimeout
-      // fires. So even though newGame() resets the hands to empty, the very next
-      // dealCardToCurrentPlayer call (triggered by useEffect) immediately mutates
-      // those same card arrays. By the time waitFor runs, the arrays are no longer
-      // empty. Fix: create a new hand object (spread) before pushing the card, and
-      // update playerCardHand's cardsToString to use `this.cards` rather than the
-      // closed-over variable so the spread copy's method still reads the right array.
+      // Player hands start fresh with no cards
+      await waitFor(() =>
+        expect(result.current.gameState.playerHands![0].cards).toHaveLength(0)
+      );
+      await waitFor(() =>
+        expect(result.current.gameState.playerHands![1].cards).toHaveLength(0)
+      );
     });
 
     test("after newGame, dealing resumes automatically", async () => {

--- a/src/hooks/use-simple-jack.tsx
+++ b/src/hooks/use-simple-jack.tsx
@@ -95,13 +95,15 @@ export function useSimpleJackGame(props?: IGameProps) {
   const stand = () => {
     if (gameState.currentPlayerIdx === 0 && gameState.playerHands?.[0]) {
       const playerHands = [...gameState.playerHands];
-      playerHands[0].hasStood = true;
+      const currentHand = playerHands[0];
+      const newHand = playerCardHand(currentHand.playerId!, currentHand.cards);
+      newHand.score = currentHand.score;
+      newHand.hasStood = true;
+      playerHands[0] = newHand;
 
       const commentary = [...gameState.commentary];
       commentary.unshift(
-        `${getPlayerDisplayName(1)} chooses to stand with ${
-          playerHands[0].score
-        }`
+        `${getPlayerDisplayName(1)} chooses to stand with ${newHand.score}`
       );
 
       // Force the next player transition immediately
@@ -144,8 +146,10 @@ export function useSimpleJackGame(props?: IGameProps) {
       (hand) => hand.cards.length >= 2
     );
 
-    updatedPlayerHands[i].cards.push(playerCard);
-    updatedPlayerHands[i].score = getHandScore(updatedPlayerHands[i].cards);
+    const currentHand = updatedPlayerHands[i];
+    const newHand = playerCardHand(currentHand.playerId!, [...currentHand.cards, playerCard]);
+    newHand.score = getHandScore(newHand.cards);
+    updatedPlayerHands[i] = newHand;
 
     const updatedCommentary = [...commentary];
     updatedCommentary.unshift(

--- a/src/lib/simple-jack.ts
+++ b/src/lib/simple-jack.ts
@@ -119,8 +119,8 @@ export function createDealValidator(): (testCard: Card) => Card {
   };
 }
 
-export function playerCardHand(id: number): PlayerHand {
-  const cards: Card[] = [];
+export function playerCardHand(id: number, initialCards: Card[] = []): PlayerHand {
+  const cards: Card[] = [...initialCards];
   const cardsToString = function (): string {
     const str = `[${cards.reduce((acc, card, idx, arr) => {
       if (idx === arr.length - 1) {


### PR DESCRIPTION
Closes #31

## Summary

- `playerCardHand` now accepts an optional `initialCards` parameter, copying them into a fresh local array so `cardsToString` always closes over the correct data — no `this`-binding required
- `dealCardToCurrentPlayer` replaces the in-place `cards.push()` and score assignment with a new hand built via `playerCardHand([...oldCards, newCard])` — the original hand objects are never touched
- `stand` applies the same pattern, replacing `playerHands[0].hasStood = true` with a freshly created hand
- Restores the previously skipped assertions in the `newGame` test that verify player hands are empty immediately after reset
- Fixes a latent stale-closure bug in the test that was masked by the mutation: the "user hits then stands" test was capturing `stand` from `result.current` before the hit updated state; changed to `result.current.stand()` so it always uses the latest closure

## Test plan

- [x] All 102 tests pass (`npx jest --coverage`)
- [x] Previously skipped `playerHands[0].cards.toHaveLength(0)` assertions now pass
- [x] `cardsToString` correctly reflects the full hand in game summaries after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)