### PR TITLE
Silence act() warning in test afterEach

### DIFF
--- a/src/__tests__/use-simple-jack.test.tsx
+++ b/src/__tests__/use-simple-jack.test.tsx
@@ -21,7 +21,7 @@ describe("useSimpleJackGame Hook", () => {
       jest.useFakeTimers();
     });
     afterEach(() => {
-      jest.runOnlyPendingTimers();
+      act(() => jest.runOnlyPendingTimers());
       jest.useRealTimers();
       jest.clearAllMocks();
     });


### PR DESCRIPTION
## Summary

- Wraps `jest.runOnlyPendingTimers()` in `act()` inside the `afterEach` hook in `use-simple-jack.test.tsx`

The bare `jest.runOnlyPendingTimers()` call was flushing pending timers (which contain `setGameState` calls) outside of `act()`, causing React Testing Library to emit a warning about untracked state updates after every test run.

## Test plan

- [x] All 102 tests pass with no console warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)