### PR TITLE
Fix game freezing after changing player count in Settings (fixes #35)

### DIFF
--- a/src/__tests__/page.test.tsx
+++ b/src/__tests__/page.test.tsx
@@ -1306,6 +1306,11 @@ describe("Simple Jack Game UI", () => {
     });
 
     // ─── scenario 10: increase players 2→4, click Start Game ────────────────
+    //
+    // Same note as scenario 9: P1 hit blackjack so hasStood=false and
+    // userCanChoose=true after startGame — the game loop short-circuits before
+    // it can race through stale hands. This does NOT catch the variant where
+    // P1 already busted or stood before the game ended.
 
     test("increasing number of players from 2 to 4 and clicking Start Game does not leave the game frozen on the old game-over state", async () => {
       jest.useFakeTimers();
@@ -1370,6 +1375,338 @@ describe("Simple Jack Game UI", () => {
       await waitFor(() =>
         expect(screen.getByTestId("player-4")).toBeInTheDocument()
       );
+    });
+
+    // ─── scenario 11: P1 busts (hits), 3 players → increase to 4, Start Game ─
+    //
+    // After P1 busts (isEliminated=true) the game ends. When the player count
+    // increases to 4 and Start Game is clicked, startGame clears gameOver but
+    // leaves the stale 3-player hands in state. The game loop sees
+    // isEliminated P1 (score≥17 → skip), P2 at 18 (skip), P3 at 19 (skip),
+    // and a phantom undefined P4, then wraps back to P1 with
+    // cardsDealtOnTurn=0 — immediately re-setting gameOver=true before
+    // useEffect([players]) can replace the hands with fresh ones.
+
+    test("increasing number of players from 3 to 4 after user busts does not leave the game frozen", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        // P1: King+5=15 → hits → +7=22 BUST
+        // P2: 8+Jack=18 (≥17, auto-stops)
+        // P3 (Dealer): 6+Queen=16 → +3=19 (wins)
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-King", "Hearts-5", "Diamonds-7"],
+              "2": ["Clubs-8", "Hearts-Jack"],
+              "3": ["Diamonds-6", "Clubs-Queen", "Hearts-3"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("3");
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /hit me/i })
+        ).toBeInTheDocument()
+      );
+
+      await waitFor(() => {
+        userEvent.click(screen.getByRole("button", { name: /hit me/i }));
+      });
+
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+      await waitFor(() =>
+        fireEvent.change(screen.getByLabelText(/your name/i), {
+          target: { value: "TestUser" },
+        })
+      );
+      await waitFor(() =>
+        fireEvent.change(
+          screen.getByRole("combobox", { name: /number of players/i }),
+          { target: { value: "4" } }
+        )
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /start game/i }));
+
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await runTimers(15);
+
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("player-1")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-2")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-3")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-4")).toBeInTheDocument()
+      );
+      expect(screen.queryByTestId("player-5")).not.toBeInTheDocument();
+    });
+
+    // ─── scenario 12: P1 busts (hits), 3 players → decrease to 2, Start Game ─
+
+    test("decreasing number of players from 3 to 2 after user busts does not leave the game frozen", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        // P1: King+5=15 → hits → +7=22 BUST
+        // P2: 8+Jack=18 (≥17, auto-stops)
+        // P3 (Dealer): 6+Queen=16 → +3=19 (wins)
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-King", "Hearts-5", "Diamonds-7"],
+              "2": ["Clubs-8", "Hearts-Jack"],
+              "3": ["Diamonds-6", "Clubs-Queen", "Hearts-3"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("3");
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /hit me/i })
+        ).toBeInTheDocument()
+      );
+
+      await waitFor(() => {
+        userEvent.click(screen.getByRole("button", { name: /hit me/i }));
+      });
+
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+      await waitFor(() =>
+        fireEvent.change(screen.getByLabelText(/your name/i), {
+          target: { value: "TestUser" },
+        })
+      );
+      await waitFor(() =>
+        fireEvent.change(
+          screen.getByRole("combobox", { name: /number of players/i }),
+          { target: { value: "2" } }
+        )
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /start game/i }));
+
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await runTimers(15);
+
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("player-1")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-2")).toBeInTheDocument()
+      );
+      expect(screen.queryByTestId("player-3")).not.toBeInTheDocument();
+    });
+
+    // ─── scenario 13: P1 stands, 2 players → increase to 3, Start Game ───────
+    //
+    // After P1 stands (hasStood=true) and the Dealer wins, startGame clears
+    // gameOver but leaves the stale 2-player hands. The game loop skips P1
+    // (hasStood), skips P2 (score≥17), then hits a phantom P3 (undefined),
+    // wraps back to P1 with cardsDealtOnTurn=0, and re-sets gameOver=true.
+
+    test("increasing number of players from 2 to 3 after user stands does not leave the game frozen", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        // P1: King+7=17 → stands
+        // P2 (Dealer): 8+Queen=18 (≥17, auto-stops, wins)
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-King", "Hearts-7"],
+              "2": ["Clubs-8", "Hearts-Queen"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("2");
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /stand/i })
+        ).toBeInTheDocument()
+      );
+
+      await waitFor(() => {
+        userEvent.click(screen.getByRole("button", { name: /stand/i }));
+      });
+
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+      await waitFor(() =>
+        fireEvent.change(screen.getByLabelText(/your name/i), {
+          target: { value: "TestUser" },
+        })
+      );
+      await waitFor(() =>
+        fireEvent.change(
+          screen.getByRole("combobox", { name: /number of players/i }),
+          { target: { value: "3" } }
+        )
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /start game/i }));
+
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await runTimers(15);
+
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("player-1")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-2")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-3")).toBeInTheDocument()
+      );
+      expect(screen.queryByTestId("player-4")).not.toBeInTheDocument();
+    });
+
+    // ─── scenario 14: P1 stands, 3 players → decrease to 2, Start Game ───────
+
+    test("decreasing number of players from 3 to 2 after user stands does not leave the game frozen", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        // P1: King+7=17 → stands
+        // P2: 8+9=17 (≥17, auto-stops)
+        // P3 (Dealer): 6+Queen=16 → +4=20 (auto-deals, wins)
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-King", "Hearts-7"],
+              "2": ["Clubs-8", "Hearts-9"],
+              "3": ["Diamonds-6", "Clubs-Queen", "Spades-4"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("3");
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /stand/i })
+        ).toBeInTheDocument()
+      );
+
+      await waitFor(() => {
+        userEvent.click(screen.getByRole("button", { name: /stand/i }));
+      });
+
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+      await waitFor(() =>
+        fireEvent.change(screen.getByLabelText(/your name/i), {
+          target: { value: "TestUser" },
+        })
+      );
+      await waitFor(() =>
+        fireEvent.change(
+          screen.getByRole("combobox", { name: /number of players/i }),
+          { target: { value: "2" } }
+        )
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /start game/i }));
+
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await runTimers(15);
+
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("player-1")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-2")).toBeInTheDocument()
+      );
+      expect(screen.queryByTestId("player-3")).not.toBeInTheDocument();
     });
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,15 @@ export default function Home() {
       // When the player count changes on a completed game, useEffect([players])
       // resets playerHands but leaves gameOver=true, freezing the game loop.
       // Reset game-over state so the loop restarts with the new count.
+      //
+      // playerHands must also be cleared here. If stale hands remain (e.g.
+      // P1 busted or stood before the game ended), the game-loop effect fires
+      // between this setGameState and the useEffect([players]) setGameState,
+      // races through every stale player, hits an undefined slot for the new
+      // higher count (or wraps immediately for a lower count), finds
+      // cardsDealtOnTurn===0, and re-sets gameOver=true. Clearing playerHands
+      // prevents the loop from running until useEffect([players]) populates
+      // fresh empty hands.
       setGameState({
         ...gameState,
         dealingSpeed: config.dealingSpeed,
@@ -36,6 +45,7 @@ export default function Home() {
         gameOver: false,
         gameSummary: undefined,
         highScore: 0,
+        playerHands: undefined,
         pushMessage: undefined,
         winner: undefined,
       });


### PR DESCRIPTION
## Summary

- Fixes #35 — game freezes on a stale result screen after changing the player count in Settings and clicking Start Game
- Adds 4 failing tests that pin the specific bug triggers before touching production code
- One-line fix in `startGame` clears stale `playerHands` so the game-loop guard prevents a race condition

## Root Cause

`startGame` (the `if`-branch that fires when `gameOver && numPlayers !== players`) correctly reset `gameOver`, `winner`, and `gameSummary`, but left the stale `playerHands` from the previous game in state. Two effects then raced:

1. `useEffect([players])` — scheduled to replace `playerHands` with fresh empty hands for the new count
2. `useEffect([gameState])` (the game loop) — fired first with the stale hands

When P1 had busted (`isEliminated: true`) or stood (`hasStood: true`) before the game ended, the game loop could not pause on `userCanChoose`. It cycled through every stale player (all at score ≥ 17 or eliminated), hit an undefined slot for the new higher count (or wrapped immediately for a lower count), found `cardsDealtOnTurn === 0`, and re-set `gameOver: true` — before `useEffect([players])` could deliver the fresh hands.

## Fix

Added `playerHands: undefined` to the reset in `startGame`'s `if`-branch (`src/app/page.tsx`). The game-loop guard `if (!gameOver && playerHands)` returns early while `playerHands` is `undefined`, and `useEffect([players])` then populates fresh empty hands before any dealing begins.

## Why Existing Tests Missed This

Scenarios 9 and 10 (the earlier regression tests) used decks where the game ended via blackjack before P1 ever had to act. P1's hand had `hasStood: false` and `isEliminated: false`, so `userCanChoose` was `true` after `startGame` and the game loop returned early — the race never fired.

## New Tests (Scenarios 11–14)

All four were committed in a failing state before the fix was applied, confirming they genuinely caught the regression:

| # | P1 action | Direction | Players |
|---|-----------|-----------|---------|
| 11 | busts (hits) | increase | 3 → 4 |
| 12 | busts (hits) | decrease | 3 → 2 |
| 13 | stands | increase | 2 → 3 |
| 14 | stands | decrease | 3 → 2 |

## Test plan

- [x] `npx jest --no-coverage` — 106/106 pass
- [x] Scenarios 11–14 failed before the fix and pass after
- [x] All 28 pre-existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)