### PR TITLE
Fix game freeze when only name or dealing speed changes after game ends

### DIFF
--- a/src/__tests__/page.test.tsx
+++ b/src/__tests__/page.test.tsx
@@ -1720,6 +1720,153 @@ describe("Simple Jack Game UI", () => {
 
       await runTimers(15);
     });
+
+    // ─── scenario 15: P1 busts, same player count, name-only change ──────────
+    //
+    // After a game ends, changing only the player name (keeping the same player
+    // count) falls into the else branch of startGame, which does not clear
+    // gameOver. The game remains frozen in the game-over state indefinitely.
+
+    test("changing only player name after game ends does not leave the game frozen", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        // P1: King+5=15 → hits → +7=22 BUST
+        // P2 (Dealer): 8+Jack=18 (≥17, wins)
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-King", "Hearts-5", "Diamonds-7"],
+              "2": ["Clubs-8", "Hearts-Jack"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("2");
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /hit me/i })
+        ).toBeInTheDocument()
+      );
+
+      await waitFor(() => {
+        userEvent.click(screen.getByRole("button", { name: /hit me/i }));
+      });
+
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+      // Change only the player name — keep player count at 2
+      await waitFor(() =>
+        fireEvent.change(screen.getByLabelText(/your name/i), {
+          target: { value: "NewName" },
+        })
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /start game/i }));
+
+      // If gameOver is not cleared, "Play New Game" appears immediately.
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("player-1")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-2")).toBeInTheDocument()
+      );
+      expect(screen.queryByTestId("player-3")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await runTimers(15);
+    });
+
+    // ─── scenario 16: P1 stands, same player count, dealing speed change ─────
+
+    test("changing only dealing speed after game ends does not leave the game frozen", async () => {
+      jest.useFakeTimers();
+
+      (useSimpleJackGame as jest.Mock).mockImplementation(() => {
+        const { useSimpleJackGame: testHook } = jest.requireActual(
+          "@/hooks/use-simple-jack"
+        );
+        // P1: King+7=17 → stands
+        // P2 (Dealer): 8+Queen=18 (≥17, wins)
+        return {
+          ...testHook({
+            deck: generateMockDeck({
+              "1": ["Spades-King", "Hearts-7"],
+              "2": ["Clubs-8", "Hearts-Queen"],
+            }),
+          }),
+        };
+      });
+
+      render(<Home />);
+      await startSetup("2");
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /stand/i })
+        ).toBeInTheDocument()
+      );
+
+      await waitFor(() => {
+        userEvent.click(screen.getByRole("button", { name: /stand/i }));
+      });
+
+      await runTimers(10);
+
+      await waitFor(() =>
+        expect(screen.getByText("WIN!")).toBeInTheDocument()
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /settings/i }));
+
+      // Change only the dealing speed — keep player count at 2 and name as-is
+      await waitFor(() =>
+        fireEvent.change(
+          screen.getByRole("combobox", { name: /dealing speed/i }),
+          { target: { value: "1000" } }
+        )
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /start game/i }));
+
+      // If gameOver is not cleared, "Play New Game" appears immediately.
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(screen.getByTestId("player-1")).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("player-2")).toBeInTheDocument()
+      );
+      expect(screen.queryByTestId("player-3")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /play new game/i })
+      ).not.toBeInTheDocument();
+
+      await runTimers(15);
+    });
   });
 
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { Player } from "@/components/player";
 import { GameSetup } from "@/components/game-setup";
 import { GameControls } from "@/components/game-controls";
 import { EDealingSpeed } from "@/shared/types";
+import { playerCardHand } from "@/lib/simple-jack";
 
 interface GameSettings {
   playerName: string;
@@ -21,19 +22,16 @@ export default function Home() {
   const [savedSettings, setSavedSettings] = useState<GameSettings | null>(null);
 
   const startGame = (config: GameSettings) => {
-    if (gameState.gameOver && config.numPlayers !== gameState.players) {
-      // When the player count changes on a completed game, useEffect([players])
-      // resets playerHands but leaves gameOver=true, freezing the game loop.
-      // Reset game-over state so the loop restarts with the new count.
+    if (gameState.gameOver) {
+      // Any settings change on a completed game must fully reset game state.
       //
-      // playerHands must also be cleared here. If stale hands remain (e.g.
-      // P1 busted or stood before the game ended), the game-loop effect fires
-      // between this setGameState and the useEffect([players]) setGameState,
-      // races through every stale player, hits an undefined slot for the new
-      // higher count (or wraps immediately for a lower count), finds
-      // cardsDealtOnTurn===0, and re-sets gameOver=true. Clearing playerHands
-      // prevents the loop from running until useEffect([players]) populates
-      // fresh empty hands.
+      // When the player count changes, useEffect([players]) will fire and
+      // create fresh hands — so playerHands is cleared to undefined to prevent
+      // the game-loop effect from racing through stale hands before that fires.
+      //
+      // When the player count stays the same, useEffect([players]) does not
+      // fire, so fresh hands are created here directly.
+      const playerCountChanging = config.numPlayers !== gameState.players;
       setGameState({
         ...gameState,
         dealingSpeed: config.dealingSpeed,
@@ -45,7 +43,11 @@ export default function Home() {
         gameOver: false,
         gameSummary: undefined,
         highScore: 0,
-        playerHands: undefined,
+        playerHands: playerCountChanging
+          ? undefined
+          : Array.from({ length: config.numPlayers }, (_, i) =>
+              playerCardHand(i + 1)
+            ),
         pushMessage: undefined,
         winner: undefined,
       });


### PR DESCRIPTION
## Summary

- The reset branch in `startGame` previously only fired when the **player count** changed on a completed game. Changing only the player name or dealing speed fell into the `else` branch, which left `gameOver: true` — freezing the game permanently.
- Broadened the condition to `gameState.gameOver` so any settings change after a game ends triggers a full reset.
- When the player count stays the same, `useEffect([players])` does not fire, so fresh hands are now created directly in `startGame` rather than relying on the effect.

## Test plan

- [ ] Scenario 15: complete a 2-player game where P1 busts, open settings, change only the player name (keep 2 players), click Start Game — game must not be frozen
- [ ] Scenario 16: complete a 2-player game where P1 stands, open settings, change only the dealing speed (keep 2 players), click Start Game — game must not be frozen
- [ ] All 123 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)